### PR TITLE
Add contact page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,7 @@ EMAILOCTOPUS_LIST_ID=
 # Create Beehiiv API key at https://developers.beehiiv.com/docs/v2/bktd9a7mxo67n-create-an-api-key
 BEEHIIV_API_KEY=
 BEEHIIV_PUBLICATION_ID=
+
+RESEND_API_KEY=
+RESEND_FROM=
+RESEND_TO=

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,31 @@
+export async function POST(req: Request) {
+  const { name, email, message } = await req.json()
+  const { RESEND_API_KEY, RESEND_FROM, RESEND_TO } = process.env
+
+  if (!RESEND_API_KEY || !RESEND_FROM || !RESEND_TO) {
+    return new Response('Server not configured', { status: 500 })
+  }
+
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${RESEND_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: RESEND_FROM,
+      to: RESEND_TO,
+      reply_to: email,
+      subject: `Contact form submission from ${name}`,
+      text: message,
+    }),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    console.error(text)
+    return new Response('Error sending email', { status: 500 })
+  }
+
+  return new Response(null, { status: 204 })
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,22 @@
+import ContactForm from '@/components/ContactForm'
+import { genPageMetadata } from 'app/seo'
+
+export const metadata = genPageMetadata({ title: 'Contact' })
+
+export default function ContactPage() {
+  return (
+    <div className="divide-y divide-gray-200 dark:divide-gray-700">
+      <div className="space-y-2 pt-6 pb-8 md:space-y-5">
+        <h1 className="text-3xl leading-9 font-extrabold tracking-tight text-gray-900 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 dark:text-gray-100">
+          Contact
+        </h1>
+        <p className="text-lg leading-7 text-gray-500 dark:text-gray-400">
+          Have a question or comment? Send a message below.
+        </p>
+      </div>
+      <div className="prose max-w-none pt-8">
+        <ContactForm />
+      </div>
+    </div>
+  )
+}

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+
+export default function ContactForm() {
+  const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle')
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    const body = {
+      name: formData.get('name'),
+      email: formData.get('email'),
+      message: formData.get('message'),
+    }
+    try {
+      setStatus('sending')
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (res.ok) {
+        setStatus('sent')
+        event.currentTarget.reset()
+      } else {
+        setStatus('error')
+      }
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <Label htmlFor="name">Name</Label>
+        <Input id="name" name="name" required />
+      </div>
+      <div>
+        <Label htmlFor="email">Email</Label>
+        <Input id="email" name="email" type="email" required />
+      </div>
+      <div>
+        <Label htmlFor="message">Message</Label>
+        <Textarea id="message" name="message" required rows={5} />
+      </div>
+      <Button type="submit" disabled={status === 'sending'}>
+        {status === 'sending' ? 'Sending...' : 'Send'}
+      </Button>
+      {status === 'sent' && (
+        <p className="text-sm text-green-600">Thanks for reaching out!</p>
+      )}
+      {status === 'error' && (
+        <p className="text-sm text-red-600">Something went wrong. Please try again.</p>
+      )}
+    </form>
+  )
+}

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -52,9 +52,7 @@ export default function ContactForm() {
       <Button type="submit" disabled={status === 'sending'}>
         {status === 'sending' ? 'Sending...' : 'Send'}
       </Button>
-      {status === 'sent' && (
-        <p className="text-sm text-green-600">Thanks for reaching out!</p>
-      )}
+      {status === 'sent' && <p className="text-sm text-green-600">Thanks for reaching out!</p>}
       {status === 'error' && (
         <p className="text-sm text-red-600">Something went wrong. Please try again.</p>
       )}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <button
+        className={cn(
+          'inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = 'Button'
+
+export { Button }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,23 +1,20 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, ...props }, ref) => {
-    return (
-      <button
-        className={cn(
-          'inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className, ...props }, ref) => {
+  return (
+    <button
+      className={cn(
+        'inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow transition-colors hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
 Button.displayName = 'Button'
 
 export { Button }

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = 'text', ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-950 dark:placeholder:text-gray-400',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = 'Input'
+
+export { Input }

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type = 'text', ...props }, ref) => {
@@ -10,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-950 dark:placeholder:text-gray-400',
+          'flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder:text-gray-500 focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-950 dark:placeholder:text-gray-400',
           className
         )}
         ref={ref}

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const Label = React.forwardRef<
+  React.ElementRef<'label'>,
+  React.ComponentPropsWithoutRef<'label'>
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(
+      'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+      className
+    )}
+    {...props}
+  />
+))
+Label.displayName = 'Label'
+
+export { Label }

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,19 +1,19 @@
+/* eslint jsx-a11y/label-has-associated-control: off */
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-const Label = React.forwardRef<
-  React.ElementRef<'label'>,
-  React.ComponentPropsWithoutRef<'label'>
->(({ className, ...props }, ref) => (
-  <label
-    ref={ref}
-    className={cn(
-      'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
-      className
-    )}
-    {...props}
-  />
-))
+const Label = React.forwardRef<React.ElementRef<'label'>, React.ComponentPropsWithoutRef<'label'>>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn(
+        'text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+        className
+      )}
+      {...props}
+    />
+  )
+)
 Label.displayName = 'Label'
 
 export { Label }

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,15 +1,14 @@
 import * as React from 'react'
 import { cn } from '@/lib/utils'
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
     return (
       <textarea
         className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-950 dark:placeholder:text-gray-400',
+          'flex min-h-[80px] w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder:text-gray-500 focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-950 dark:placeholder:text-gray-400',
           className
         )}
         ref={ref}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          'flex min-h-[80px] w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-950 dark:placeholder:text-gray-400',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = 'Textarea'
+
+export { Textarea }

--- a/data/headerNavLinks.ts
+++ b/data/headerNavLinks.ts
@@ -4,6 +4,7 @@ const headerNavLinks = [
   { href: '/tags', title: 'Tags' },
   // TODO: Add custom projects before re-enabling the Projects link
   // { href: '/projects', title: 'Projects' },
+  { href: '/contact', title: 'Contact' },
   { href: '/about', title: 'About' },
 ]
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | undefined | false | null>) {
+  return classes.filter(Boolean).join(' ')
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
       "@/data/*": ["data/*"],
       "@/layouts/*": ["layouts/*"],
       "@/css/*": ["css/*"],
+      "@/lib/*": ["lib/*"],
       "contentlayer/generated": ["./.contentlayer/generated"],
       "pliny/*": ["node_modules/pliny/*"]
     },


### PR DESCRIPTION
## Summary
- add a simple utility for classnames
- create shadcn-inspired UI components
- implement contact form and API route using Resend
- expose config vars in `.env.example`
- add Contact to site navigation
- map new `@/lib/*` path alias

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68518caf50dc8322833f8d5c4c402360