### PR TITLE
fix: migrate newsletter signup from Resend audiences to contacts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,4 +33,4 @@ RESEND_API_KEY=
 CONTACT_FORM_RECIPIENT=
 
 # Newsletter
-RESEND_AUDIENCE_ID=
+# Uses Resend global contacts (audiences are deprecated)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ The goal is to fail fast when required values are missing and keep local, previe
 - `POLAR_PRODUCT_ID_ANNUAL`
 - `POLAR_API_BASE_URL` (default: `https://api.polar.sh`)
 - `RESEND_API_KEY`
-- `RESEND_AUDIENCE_ID`
 - `CONTACT_FORM_RECIPIENT`
 - `VERCEL_AUTOMATION_BYPASS_SECRET` (required for preview-protection bypass when calling internal routes)
 
@@ -84,7 +83,11 @@ Newsletter subscriptions now run through a first-party endpoint:
 Required variables:
 
 - `RESEND_API_KEY`
-- `RESEND_AUDIENCE_ID`
+
+Notes:
+
+- Newsletter subscriptions use Resend global contacts.
+- `RESEND_AUDIENCE_ID` is deprecated and not required.
 
 Response contract:
 

--- a/__tests__/api/newsletter.test.ts
+++ b/__tests__/api/newsletter.test.ts
@@ -6,28 +6,28 @@ type LoadRouteOptions = {
   envOverrides?: Partial<{
     RESEND_API_KEY: string
   }>
-  createResponse?: {
-    data: unknown
-    error: { message?: string; name?: string } | null
-  }
+  fetchStatus?: number
+  fetchJsonBody?: unknown
+  fetchReject?: Error
 }
 
 async function loadRoute(options: LoadRouteOptions = {}) {
-  const contactsCreate = jest.fn().mockResolvedValue(
-    options.createResponse ?? {
-      data: { id: 'contact_123' },
-      error: null,
-    }
-  )
+  const fetchMock = jest.fn()
+
+  if (options.fetchReject) {
+    fetchMock.mockRejectedValue(options.fetchReject)
+  } else {
+    const status = options.fetchStatus ?? 200
+    fetchMock.mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      json: jest.fn().mockResolvedValue(options.fetchJsonBody ?? { id: 'contact_123' }),
+    })
+  }
+
+  ;(global as unknown as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
 
   jest.resetModules()
-  jest.doMock('resend', () => ({
-    Resend: jest.fn().mockImplementation(() => ({
-      contacts: {
-        create: contactsCreate,
-      },
-    })),
-  }))
 
   jest.doMock('lib/env', () => ({
     env: {
@@ -39,7 +39,7 @@ async function loadRoute(options: LoadRouteOptions = {}) {
   const route = (await import('../../app/api/newsletter/route')) as NewsletterRouteModule
   return {
     POST: route.POST,
-    contactsCreate,
+    fetchMock,
   }
 }
 
@@ -91,7 +91,7 @@ describe('Newsletter API (/api/newsletter)', () => {
   })
 
   it('returns 200 for successful subscriptions', async () => {
-    const { POST, contactsCreate } = await loadRoute()
+    const { POST, fetchMock } = await loadRoute()
     const response = await POST(
       new Request('http://localhost/api/newsletter', {
         method: 'POST',
@@ -104,7 +104,18 @@ describe('Newsletter API (/api/newsletter)', () => {
     expect(response.status).toBe(200)
     expect(body.ok).toBe(true)
     expect(body.code).toBe('OK')
-    expect(contactsCreate).toHaveBeenCalledWith({
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.resend.com/contacts',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer re_test',
+          'Content-Type': 'application/json',
+        }),
+      })
+    )
+    const [, callInit] = fetchMock.mock.calls[0]
+    expect(JSON.parse(callInit.body as string)).toEqual({
       email: 'reader@example.com',
       unsubscribed: false,
     })
@@ -112,12 +123,9 @@ describe('Newsletter API (/api/newsletter)', () => {
 
   it('treats existing contacts as successful idempotent subscriptions', async () => {
     const { POST } = await loadRoute({
-      createResponse: {
-        data: null,
-        error: {
-          name: 'validation_error',
-          message: 'Contact already exists',
-        },
+      fetchStatus: 409,
+      fetchJsonBody: {
+        message: 'Contact already exists',
       },
     })
     const response = await POST(
@@ -136,12 +144,9 @@ describe('Newsletter API (/api/newsletter)', () => {
 
   it('returns 502 when Resend contacts API fails', async () => {
     const { POST } = await loadRoute({
-      createResponse: {
-        data: null,
-        error: {
-          name: 'internal_server_error',
-          message: 'Resend is unavailable',
-        },
+      fetchStatus: 500,
+      fetchJsonBody: {
+        message: 'Resend is unavailable',
       },
     })
     const response = await POST(

--- a/__tests__/api/newsletter.test.ts
+++ b/__tests__/api/newsletter.test.ts
@@ -5,7 +5,6 @@ type NewsletterRouteModule = {
 type LoadRouteOptions = {
   envOverrides?: Partial<{
     RESEND_API_KEY: string
-    RESEND_AUDIENCE_ID: string
   }>
   createResponse?: {
     data: unknown
@@ -33,7 +32,6 @@ async function loadRoute(options: LoadRouteOptions = {}) {
   jest.doMock('lib/env', () => ({
     env: {
       RESEND_API_KEY: 're_test',
-      RESEND_AUDIENCE_ID: 'aud_test',
       ...options.envOverrides,
     },
   }))
@@ -75,7 +73,7 @@ describe('Newsletter API (/api/newsletter)', () => {
   it('returns 500 when required Resend config is missing', async () => {
     const { POST } = await loadRoute({
       envOverrides: {
-        RESEND_AUDIENCE_ID: '',
+        RESEND_API_KEY: '',
       },
     })
     const response = await POST(
@@ -107,7 +105,6 @@ describe('Newsletter API (/api/newsletter)', () => {
     expect(body.ok).toBe(true)
     expect(body.code).toBe('OK')
     expect(contactsCreate).toHaveBeenCalledWith({
-      audienceId: 'aud_test',
       email: 'reader@example.com',
       unsubscribed: false,
     })
@@ -137,7 +134,7 @@ describe('Newsletter API (/api/newsletter)', () => {
     expect(body.code).toBe('OK_ALREADY_SUBSCRIBED')
   })
 
-  it('returns 502 when Resend audience API fails', async () => {
+  it('returns 502 when Resend contacts API fails', async () => {
     const { POST } = await loadRoute({
       createResponse: {
         data: null,

--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -25,7 +25,7 @@ function isAlreadySubscribedError(error: { message?: string | null } | null | un
 }
 
 export async function POST(request: Request) {
-  if (!env.RESEND_API_KEY || !env.RESEND_AUDIENCE_ID) {
+  if (!env.RESEND_API_KEY) {
     const body: NewsletterResponse = {
       ok: false,
       code: ErrorCodes.MissingConfig,
@@ -55,7 +55,6 @@ export async function POST(request: Request) {
 
   const resend = new Resend(env.RESEND_API_KEY)
   const { error } = await resend.contacts.create({
-    audienceId: env.RESEND_AUDIENCE_ID,
     email,
     unsubscribed: false,
   })

--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server'
-import { Resend } from 'resend'
 import { env } from 'lib/env'
 
 export const dynamic = 'force-dynamic'
@@ -22,6 +21,36 @@ function isAlreadySubscribedError(error: { message?: string | null } | null | un
   if (!error?.message) return false
   const message = error.message.toLowerCase()
   return message.includes('already exists') || message.includes('already subscribed')
+}
+
+async function createResendContact(apiKey: string, email: string) {
+  const response = await fetch('https://api.resend.com/contacts', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email,
+      unsubscribed: false,
+    }),
+  })
+
+  if (response.ok) {
+    return { error: null as { message?: string | null } | null }
+  }
+
+  const parsedBody = (await response.json().catch(() => null)) as {
+    message?: string
+    error?: { message?: string }
+  } | null
+
+  const message =
+    parsedBody?.message ||
+    parsedBody?.error?.message ||
+    `Resend contact request failed (${response.status})`
+
+  return { error: { message } }
 }
 
 export async function POST(request: Request) {
@@ -53,11 +82,19 @@ export async function POST(request: Request) {
     return NextResponse.json(body, { status: 400 })
   }
 
-  const resend = new Resend(env.RESEND_API_KEY)
-  const { error } = await resend.contacts.create({
-    email,
-    unsubscribed: false,
-  })
+  let error: { message?: string | null } | null = null
+  try {
+    const result = await createResendContact(env.RESEND_API_KEY, email)
+    error = result.error
+  } catch (requestError) {
+    console.error('Newsletter subscribe error:', requestError)
+    const body: NewsletterResponse = {
+      ok: false,
+      code: ErrorCodes.Upstream,
+      message: "We couldn't subscribe you right now. Please try again shortly.",
+    }
+    return NextResponse.json(body, { status: 502 })
+  }
 
   if (error) {
     if (isAlreadySubscribedError(error)) {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -44,7 +44,6 @@ const envSchema = z.object({
     .url('POLAR_API_BASE_URL must be a URL')
     .default('https://api.polar.sh'),
   RESEND_API_KEY: z.string().trim().optional(),
-  RESEND_AUDIENCE_ID: z.string().trim().optional(),
   CONTACT_FORM_RECIPIENT: z
     .string()
     .trim()


### PR DESCRIPTION
## Summary
- migrate newsletter signup off deprecated Resend audiences
- use Resend contacts create without udienceId
- remove runtime dependency on RESEND_AUDIENCE_ID
- update docs and env examples for the new contract

## Changes
- pp/api/newsletter/route.ts
- __tests__/api/newsletter.test.ts
- lib/env.ts
- .env.example
- README.md

## Validation
- yarn test -- __tests__/api/newsletter.test.ts

Closes #74