### PR TITLE
[codex] Add services page and newsletter signup updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,13 @@
 # testing
 /coverage
 test-results/
+/dogfood-output/report.md
+/dogfood-output/screenshots/
+/dogfood-output/videos/
 
 # playwright
 /playwright-report/
+/.playwright-mcp/
 
 # backup files
 *.backup
@@ -49,6 +53,7 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+.env.local.backup-*
 
 # Contentlayer
 .contentlayer

--- a/app/(site)/Main.tsx
+++ b/app/(site)/Main.tsx
@@ -2,7 +2,6 @@ import Link from '@/components/Link'
 import NewsletterForm from '@/components/NewsletterForm'
 import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
-import { formatDate } from 'pliny/utils/formatDate'
 import type { SiteAuthor, SitePost } from 'src/payload/types'
 
 const MAX_DISPLAY = 5
@@ -18,57 +17,59 @@ export default function Home({ posts, defaultAuthor }: HomeProps) {
       <div className="divide-y divide-gray-200 dark:divide-gray-700">
         <div className="space-y-2 pt-6 pb-8 md:space-y-5">
           <h1 className="text-3xl leading-9 font-extrabold tracking-tight text-gray-900 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 dark:text-gray-100">
-            {siteMetadata.description}
+            The{' '}
+            <span className="text-primary-500 dark:text-primary-400 font-serif font-medium italic">
+              business
+            </span>{' '}
+            of developer tools
           </h1>
           <p className="text-lg leading-7 text-gray-500 dark:text-gray-400">
-            Edited by {defaultAuthor?.name}
+            Edited by{' '}
+            <Link
+              href="/about"
+              className="hover:text-primary-500 dark:hover:text-primary-400 text-gray-600 underline-offset-4 hover:underline dark:text-gray-300"
+            >
+              {defaultAuthor?.name}
+            </Link>
           </p>
+          {siteMetadata.newsletter?.provider && (
+            <div className="pt-4">
+              <NewsletterForm inputId="home-newsletter-email-top" />
+            </div>
+          )}
         </div>
         <ul className="divide-y divide-gray-200 dark:divide-gray-700">
           {!posts.length && 'No posts found.'}
           {posts.slice(0, MAX_DISPLAY).map((post) => {
-            const { slug, date, title, summary, tags } = post
+            const { slug, title, summary, tags } = post
             return (
               <li key={slug} className="py-12">
-                <article>
-                  <div className="space-y-2 xl:grid xl:grid-cols-4 xl:items-baseline xl:space-y-0">
-                    <dl>
-                      <dt className="sr-only">Published on</dt>
-                      <dd className="text-base leading-6 font-medium text-gray-500 dark:text-gray-400">
-                        <time dateTime={date}>{formatDate(date, siteMetadata.locale)}</time>
-                      </dd>
-                    </dl>
-                    <div className="space-y-5 xl:col-span-3">
-                      <div className="space-y-6">
-                        <div>
-                          <h2 className="text-2xl leading-8 font-bold tracking-tight">
-                            <Link
-                              href={`/blog/${slug}`}
-                              className="text-gray-900 dark:text-gray-100"
-                            >
-                              {title}
-                            </Link>
-                          </h2>
-                          <div className="flex flex-wrap">
-                            {(tags || []).map((tag) => (
-                              <Tag key={tag} text={tag} />
-                            ))}
-                          </div>
-                        </div>
-                        <div className="prose max-w-none text-gray-500 dark:text-gray-400">
-                          {summary}
-                        </div>
-                      </div>
-                      <div className="text-base leading-6 font-medium">
-                        <Link
-                          href={`/blog/${slug}`}
-                          className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-                          aria-label={`Read more: "${title}"`}
-                        >
-                          Read more &rarr;
+                <article className="max-w-3xl space-y-5">
+                  <div className="space-y-6">
+                    <div>
+                      <h2 className="text-2xl leading-8 font-bold tracking-tight">
+                        <Link href={`/blog/${slug}`} className="text-gray-900 dark:text-gray-100">
+                          {title}
                         </Link>
+                      </h2>
+                      <div className="flex flex-wrap">
+                        {(tags || []).map((tag) => (
+                          <Tag key={tag} text={tag} />
+                        ))}
                       </div>
                     </div>
+                    <div className="prose max-w-none text-gray-500 dark:text-gray-400">
+                      {summary}
+                    </div>
+                  </div>
+                  <div className="text-base leading-6 font-medium">
+                    <Link
+                      href={`/blog/${slug}`}
+                      className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                      aria-label={`Read more: "${title}"`}
+                    >
+                      Read more &rarr;
+                    </Link>
                   </div>
                 </article>
               </li>
@@ -89,7 +90,7 @@ export default function Home({ posts, defaultAuthor }: HomeProps) {
       )}
       {siteMetadata.newsletter?.provider && (
         <div className="flex items-center justify-center pt-4">
-          <NewsletterForm />
+          <NewsletterForm inputId="home-newsletter-email-bottom" />
         </div>
       )}
     </>

--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -1,36 +1,238 @@
-import { RichText } from '@payloadcms/richtext-lexical/react'
-import type { ComponentProps } from 'react'
-import AuthorLayout from '@/layouts/AuthorLayout'
+import ContactForm from '@/components/ContactForm'
+import SectionContainer from '@/components/SectionContainer'
 import { genPageMetadata } from 'app/seo'
-import { getDefaultAuthor } from 'lib/cms'
-
-type LexicalRichTextData = ComponentProps<typeof RichText>['data']
 
 export const dynamic = 'force-static'
-export const metadata = genPageMetadata({ title: 'About' })
+export const metadata = genPageMetadata({
+  title: 'Services',
+  description:
+    'Fractional product marketing, launch strategy, messaging, and trust assets for developer tool startups.',
+})
 
-export default async function Page() {
-  const author = await getDefaultAuthor()
-  if (!author) {
-    return (
-      <section className="pt-6 pb-8 md:space-y-5">
-        <h1 className="text-3xl leading-9 font-extrabold tracking-tight text-gray-900 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 dark:text-gray-100">
-          About
-        </h1>
-        <p className="text-lg leading-7 text-gray-500 dark:text-gray-400">
-          Author profile is temporarily unavailable. Please check back soon.
-        </p>
-      </section>
-    )
-  }
+const engagements = [
+  {
+    team: 'Developer infrastructure startup',
+    work: 'Use case strategy, case study development, launch messaging, and sales narrative',
+    result: 'Turned technical wins into trust assets for sales conversations',
+  },
+  {
+    team: 'AI framework company',
+    work: 'Founder-led LinkedIn, Reddit strategy, technical thought leadership, and SEO content',
+    result: 'Built category credibility with developers and AI builders',
+  },
+  {
+    team: 'Product notification platform',
+    work: 'Case studies, G2 review motion, technical launch content, and enterprise-readiness assets',
+    result: 'Helped position the company as a vendor of choice in competitive deals',
+  },
+]
 
+const services = [
+  {
+    title: 'Fractional Product Marketing Leadership',
+    body: 'Embedded, part-time product marketing leadership for developer tool startups that need senior judgment without hiring a full-time GTM leader. I help clarify positioning, shape launches, manage vendors, build trust assets, and create a product-first marketing rhythm.',
+  },
+  {
+    title: 'Enterprise-Ready Messaging Sprint',
+    body: 'A focused sprint that turns your product, customer proof, and founder vision into messaging enterprise buyers can trust. You leave with a practical system your team, salespeople, agencies, and freelancers can actually use.',
+  },
+  {
+    title: 'Trust Asset Program',
+    body: 'Case studies, testimonials, use cases, implementation stories, comparison pages, and thought leadership built around the real reasons customers choose you. I run the process end to end, from interviews through narrative and approval.',
+  },
+  {
+    title: 'Vendor and Freelancer Management',
+    body: 'I help source, brief, and manage outside talent so agencies, consultants, and freelancers move faster and produce work that matches your product strategy.',
+  },
+  {
+    title: 'Product Launches',
+    body: 'Launch strategy and execution for developer tool startups that need product announcements to do more than ship news. I turn new features, integrations, funding moments, and major product updates into credible launch narratives and sales assets.',
+  },
+]
+
+const comparison = [
+  [
+    'Enterprise-ready strategy',
+    'Executes a defined brief',
+    'Owns strategy over time',
+    'Sets strategy quickly and aligns everyone around it',
+  ],
+  [
+    'Technical product fluency',
+    'Varies widely',
+    'Hard to find and expensive',
+    'Brings product marketing judgment for technical buyers',
+  ],
+  [
+    'Speed',
+    'Can move fast once scoped',
+    'Slower during hiring and ramping',
+    'Starts with diagnosis, prioritization, and clear briefs',
+  ],
+  [
+    'Customer proof',
+    'Needs strong direction',
+    'Builds the function over time',
+    'Runs interviews, story development, review, and approval',
+  ],
+  [
+    'Cost and commitment',
+    'Often requires retainers',
+    'Highest long-term commitment',
+    'Flexible senior help without early GTM bloat',
+  ],
+]
+
+export default function ServicesPage() {
   return (
-    <AuthorLayout content={author}>
-      {author.bioRichText ? (
-        <RichText data={author.bioRichText as LexicalRichTextData} />
-      ) : (
-        <p>Author profile is coming soon.</p>
-      )}
-    </AuthorLayout>
+    <SectionContainer>
+      <div className="py-10 md:py-14">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start">
+          <main className="min-w-0 space-y-14">
+            <section className="space-y-6">
+              <h1 className="text-4xl leading-tight font-extrabold tracking-tight text-gray-900 sm:text-5xl dark:text-gray-100">
+                I help you cross the chasm and win enterprise customers.
+              </h1>
+              <div className="space-y-5 text-lg leading-8 text-gray-600 dark:text-gray-300">
+                <p>
+                  Hi, I am Hashim Warren. I am a fractional product marketing leader for developer
+                  tool startups. My specialty is turning early technical traction into
+                  enterprise-ready marketing.
+                </p>
+                <p>
+                  You already did the hard part: you built a product early adopters love and reached
+                  product-market fit. The next challenge is winning complex enterprise deals without
+                  overhiring GTM talent or losing product focus.
+                </p>
+                <p>
+                  I turn early wins into the case studies, use cases, launch narratives, thought
+                  leadership, and sales collateral that help serious buyers trust you.
+                </p>
+              </div>
+            </section>
+
+            <section className="space-y-6">
+              <div>
+                <h2 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
+                  Recent Engagements
+                </h2>
+                <p className="mt-2 text-gray-600 dark:text-gray-400">
+                  Practical product marketing work for technical teams moving from founder-led GTM
+                  toward enterprise-ready sales.
+                </p>
+              </div>
+              <div className="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
+                <div className="divide-y divide-gray-200 dark:divide-gray-800">
+                  {engagements.map((engagement) => (
+                    <div
+                      key={engagement.team}
+                      className="grid gap-4 bg-white p-5 sm:grid-cols-3 dark:bg-gray-950"
+                    >
+                      <h3 className="font-semibold text-gray-900 dark:text-gray-100">
+                        {engagement.team}
+                      </h3>
+                      <p className="text-sm leading-6 text-gray-600 dark:text-gray-400">
+                        {engagement.work}
+                      </p>
+                      <p className="text-sm leading-6 text-gray-600 dark:text-gray-400">
+                        {engagement.result}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </section>
+
+            <section className="space-y-6">
+              <h2 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
+                How We Can Work Together
+              </h2>
+              <div className="space-y-8">
+                {services.map((service) => (
+                  <article key={service.title} className="space-y-2">
+                    <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+                      {service.title}
+                    </h3>
+                    <p className="leading-7 text-gray-600 dark:text-gray-400">{service.body}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section className="space-y-6">
+              <div>
+                <h2 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
+                  Fractional vs. Agency vs. In-House
+                </h2>
+                <p className="mt-2 leading-7 text-gray-600 dark:text-gray-400">
+                  The common mistake is hiring the wrong way too early. A developer tool startup may
+                  need more marketing capacity, but it first needs the right GTM shape: strategy,
+                  proof, priorities, and clear ownership.
+                </p>
+              </div>
+              <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-800">
+                <table className="min-w-[760px] divide-y divide-gray-200 text-left text-sm dark:divide-gray-800">
+                  <thead className="bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+                    <tr>
+                      <th scope="col" className="px-4 py-3 font-semibold">
+                        What you need
+                      </th>
+                      <th scope="col" className="px-4 py-3 font-semibold">
+                        Agency
+                      </th>
+                      <th scope="col" className="px-4 py-3 font-semibold">
+                        In-house hire
+                      </th>
+                      <th scope="col" className="px-4 py-3 font-semibold">
+                        Fractional product marketing leader
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-800 dark:bg-gray-950">
+                    {comparison.map(([need, agency, inHouse, fractional]) => (
+                      <tr key={need}>
+                        <th
+                          scope="row"
+                          className="px-4 py-4 font-semibold text-gray-900 dark:text-gray-100"
+                        >
+                          {need}
+                        </th>
+                        <td className="px-4 py-4 text-gray-600 dark:text-gray-400">{agency}</td>
+                        <td className="px-4 py-4 text-gray-600 dark:text-gray-400">{inHouse}</td>
+                        <td className="px-4 py-4 text-gray-600 dark:text-gray-400">{fractional}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-800 dark:bg-gray-900/40">
+              <h2 className="text-xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
+                Something else in mind?
+              </h2>
+              <p className="mt-3 leading-7 text-gray-600 dark:text-gray-400">
+                If you are building a technical product and trying to win a more serious customer
+                than the one you started with, I can help turn what you already have into the GTM
+                assets buyers need to believe you.
+              </p>
+            </section>
+          </main>
+
+          <aside className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm lg:sticky lg:top-24 dark:border-gray-800 dark:bg-gray-950">
+            <div className="mb-6 space-y-2">
+              <h2 className="text-xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
+                Talk About Services
+              </h2>
+              <p className="text-sm leading-6 text-gray-600 dark:text-gray-400">
+                Tell me what you are building, what kind of buyer you need to win, and what proof or
+                launch work is missing.
+              </p>
+            </div>
+            <ContactForm />
+          </aside>
+        </div>
+      </div>
+    </SectionContainer>
   )
 }

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -3,6 +3,7 @@ import 'pliny/search/algolia.css'
 import 'remark-github-blockquote-alert/alert.css'
 
 import { Space_Grotesk } from 'next/font/google'
+import Script from 'next/script'
 import { Analytics, AnalyticsConfig } from 'pliny/analytics'
 import { SearchProvider, SearchConfig } from 'pliny/search'
 import Header from '@/components/Header'
@@ -62,8 +63,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang={siteMetadata.language} className={space_grotesk.variable} suppressHydrationWarning>
       <head>
-        {/* Keep only the favicon.ico reference */}
-        <link rel="icon" href="/favicon.ico" sizes="any" />
+        <link rel="icon" href="/static/favicons/favicon.ico" sizes="any" />
 
         {/* TODO: Add custom favicons to replace these hidden references */}
         {/* 
@@ -87,6 +87,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </SearchProvider>
             <Footer />
           </SectionContainer>
+          {process.env.NODE_ENV === 'development' && <Script src="https://ui.sh/ui-picker.js" />}
         </ThemeProviders>
       </body>
     </html>

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -10,6 +10,17 @@ const ErrorCodes = {
   REQUEST_PROCESSING: 'ERR_REQUEST_PROCESSING',
 } as const
 
+const CONTACT_FORM_FROM = process.env.CONTACT_FORM_FROM || 'Hypeburner <hello@hypeburner.com>'
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
 export async function POST(request: Request) {
   // Environment variable validation
   if (!process.env.RESEND_API_KEY) {
@@ -37,7 +48,12 @@ export async function POST(request: Request) {
   try {
     // Instantiate Resend lazily to avoid build-time env access
     const resend = new Resend(process.env.RESEND_API_KEY)
-    const { name, email, message } = await request.json()
+    const payload = await request.json()
+    const name = String(payload?.name || '').trim()
+    const email = String(payload?.email || '')
+      .trim()
+      .toLowerCase()
+    const message = String(payload?.message || '').trim()
 
     // Validate required fields
     if (!name || !email || !message) {
@@ -64,22 +80,43 @@ export async function POST(request: Request) {
       )
     }
 
+    const escapedName = escapeHtml(name)
+    const escapedEmail = escapeHtml(email)
+    const escapedMessageHtml = escapeHtml(message).replace(/\n/g, '<br />')
+    const text = [
+      'New Contact Form Submission',
+      '',
+      `Name: ${name}`,
+      `Email: ${email}`,
+      '',
+      'Message:',
+      message,
+    ].join('\n')
+
     const emailHtml = `
       <div>
         <h1>New Contact Form Submission</h1>
-        <p><strong>Name:</strong> ${name}</p>
-        <p><strong>Email:</strong> ${email}</p>
+        <p><strong>Name:</strong> ${escapedName}</p>
+        <p><strong>Email:</strong> ${escapedEmail}</p>
         <p><strong>Message:</strong></p>
-        <p>${message}</p>
+        <p>${escapedMessageHtml}</p>
       </div>
     `
 
-    const { data, error } = await resend.emails.send({
-      from: 'Contact Form <onboarding@resend.dev>',
-      to: process.env.CONTACT_FORM_RECIPIENT!,
-      subject: 'New Contact Form Submission',
-      html: emailHtml,
-    })
+    const { data, error } = await resend.emails.send(
+      {
+        from: CONTACT_FORM_FROM,
+        to: process.env.CONTACT_FORM_RECIPIENT!,
+        subject: `New services inquiry from ${name}`,
+        html: emailHtml,
+        text,
+        replyTo: [email],
+        tags: [{ name: 'source', value: 'contact_form' }],
+      },
+      {
+        idempotencyKey: `contact-form/${email}/${Date.now()}`,
+      }
+    )
 
     if (error) {
       console.error('Error sending email:', error)

--- a/components/NewsletterForm.tsx
+++ b/components/NewsletterForm.tsx
@@ -1,13 +1,27 @@
 'use client'
 
-import { useState } from 'react'
+import { ReactNode, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { cn } from '@/components/lib/utils'
 
 type NewsletterFormProps = {
-  title?: string
-  description?: string
+  title?: string | null
+  description?: string | null
   compact?: boolean
+  inputId?: string
+  className?: string
+  headerClassName?: string
+  titleClassName?: string
+  descriptionClassName?: string
+  formClassName?: string
+  inputClassName?: string
+  buttonClassName?: string
+  buttonVariant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link'
+  buttonSize?: 'default' | 'sm' | 'lg' | 'icon'
+  statusClassName?: string
+  beforeForm?: ReactNode
+  afterForm?: ReactNode
 }
 
 type SubmitState = 'idle' | 'submitting' | 'success' | 'error'
@@ -22,10 +36,25 @@ function isValidEmail(value: string): boolean {
 }
 
 export default function NewsletterForm({
-  title = 'Subscribe to the newsletter',
-  description = 'Get new posts and launch breakdowns in your inbox.',
+  title,
+  description,
   compact = false,
+  inputId = 'newsletter-email',
+  className,
+  headerClassName,
+  titleClassName,
+  descriptionClassName,
+  formClassName,
+  inputClassName,
+  buttonClassName,
+  buttonVariant = 'default',
+  buttonSize = 'default',
+  statusClassName,
+  beforeForm,
+  afterForm,
 }: NewsletterFormProps) {
+  const resolvedTitle = title ?? 'Subscribe to the newsletter'
+  const resolvedDescription = description ?? 'Get new posts and launch breakdowns in your inbox.'
   const [email, setEmail] = useState('')
   const [state, setState] = useState<SubmitState>('idle')
   const [message, setMessage] = useState('')
@@ -73,18 +102,41 @@ export default function NewsletterForm({
   }
 
   return (
-    <div className={`w-full ${compact ? 'max-w-lg' : 'max-w-2xl'} rounded-xl border p-6`}>
-      <div className="space-y-1">
-        <h2 className={`${compact ? 'text-lg' : 'text-xl'} font-semibold`}>{title}</h2>
-        <p className="text-sm text-gray-600 dark:text-gray-400">{description}</p>
-      </div>
+    <div
+      className={cn('w-full rounded-xl border p-6', compact ? 'max-w-lg' : 'max-w-2xl', className)}
+    >
+      {(resolvedTitle || resolvedDescription) && (
+        <div className={cn('space-y-1', headerClassName)}>
+          {resolvedTitle && (
+            <h2
+              className={cn(
+                compact ? 'text-lg font-semibold' : 'text-xl font-semibold',
+                titleClassName
+              )}
+            >
+              {resolvedTitle}
+            </h2>
+          )}
+          {resolvedDescription && (
+            <p className={cn('text-sm text-gray-600 dark:text-gray-400', descriptionClassName)}>
+              {resolvedDescription}
+            </p>
+          )}
+        </div>
+      )}
 
-      <form onSubmit={onSubmit} className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center">
-        <label htmlFor="newsletter-email" className="sr-only">
+      {beforeForm}
+
+      <form
+        onSubmit={onSubmit}
+        className={cn('mt-4 flex flex-col gap-3 sm:flex-row sm:items-center', formClassName)}
+      >
+        <label htmlFor={inputId} className="sr-only">
           Email address
         </label>
         <Input
-          id="newsletter-email"
+          id={inputId}
+          name="email"
           type="email"
           autoComplete="email"
           value={email}
@@ -92,23 +144,34 @@ export default function NewsletterForm({
           placeholder="you@example.com"
           disabled={state === 'submitting'}
           aria-invalid={state === 'error'}
+          className={inputClassName}
         />
-        <Button type="submit" disabled={state === 'submitting'}>
+        <Button
+          type="submit"
+          disabled={state === 'submitting'}
+          variant={buttonVariant}
+          size={buttonSize}
+          className={buttonClassName}
+        >
           {state === 'submitting' ? 'Subscribing...' : 'Subscribe'}
         </Button>
       </form>
 
       {state !== 'idle' && (
         <p
-          className={`mt-3 text-sm ${
+          className={cn(
+            'mt-3 text-sm',
             state === 'success'
               ? 'text-green-700 dark:text-green-400'
-              : 'text-red-700 dark:text-red-400'
-          }`}
+              : 'text-red-700 dark:text-red-400',
+            statusClassName
+          )}
         >
           {message}
         </p>
       )}
+
+      {afterForm}
     </div>
   )
 }

--- a/components/NewsletterForm.tsx
+++ b/components/NewsletterForm.tsx
@@ -53,8 +53,9 @@ export default function NewsletterForm({
   beforeForm,
   afterForm,
 }: NewsletterFormProps) {
-  const resolvedTitle = title ?? 'Subscribe to the newsletter'
-  const resolvedDescription = description ?? 'Get new posts and launch breakdowns in your inbox.'
+  const resolvedTitle = title === undefined ? 'Subscribe to the newsletter' : title
+  const resolvedDescription =
+    description === undefined ? 'Get new posts and launch breakdowns in your inbox.' : description
   const [email, setEmail] = useState('')
   const [state, setState] = useState<SubmitState>('idle')
   const [message, setMessage] = useState('')

--- a/components/PostSubscribeBox.tsx
+++ b/components/PostSubscribeBox.tsx
@@ -1,0 +1,148 @@
+import NewsletterForm from './NewsletterForm'
+import siteMetadata from '@/data/siteMetadata'
+
+const promisePoints = [
+  'One sharp email per issue',
+  'Launch analysis, not noise',
+  'Easy unsubscribe',
+]
+
+function PromiseRow() {
+  return (
+    <div className="mt-6 grid gap-3 border-t border-gray-950/10 pt-4 text-sm text-gray-600 sm:grid-cols-3 dark:border-white/10 dark:text-gray-300">
+      {promisePoints.map((point) => (
+        <p key={point} className="text-pretty">
+          {point}
+        </p>
+      ))}
+    </div>
+  )
+}
+
+export default function PostSubscribeBox() {
+  if (!siteMetadata.newsletter?.provider) return null
+
+  return (
+    <div className="mt-8">
+      <div data-uidotsh-pick="Post subscribe box" className="contents">
+        <div data-uidotsh-option="Editorial split" className="contents">
+          <section className="mx-auto max-w-3xl rounded-[1.75rem] border border-gray-950/10 bg-linear-to-br from-white via-white to-gray-50/80 p-6 text-left sm:p-8 dark:border-white/10 dark:from-gray-950 dark:via-gray-950 dark:to-gray-900/80">
+            <div className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.9fr)] lg:items-end">
+              <div className="space-y-4">
+                <p className="font-mono text-sm tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                  Weekly devtools signal
+                </p>
+                <div className="space-y-3">
+                  <h2 className="max-w-[20ch] text-2xl font-semibold tracking-tight text-balance text-gray-950 sm:text-3xl dark:text-white">
+                    Get the next issue before the next launch cycle starts.
+                  </h2>
+                  <p className="max-w-[48ch] text-base text-pretty text-gray-600 dark:text-gray-300">
+                    Subscribe for concise breakdowns of product launches, positioning moves, and
+                    what smart teams can steal from them.
+                  </p>
+                </div>
+              </div>
+              <NewsletterForm
+                compact
+                title=""
+                description=""
+                inputId="post-newsletter-editorial"
+                className="max-w-none rounded-[1.5rem] border-gray-950/10 bg-white/80 p-4 backdrop-blur dark:border-white/10 dark:bg-white/5"
+                formClassName="mt-0 flex-col gap-2 sm:flex-col sm:items-stretch"
+                inputClassName="border-0 bg-white text-base ring-1 ring-black/10 dark:bg-gray-950 dark:ring-white/10"
+                buttonClassName="w-full"
+              />
+            </div>
+            <PromiseRow />
+          </section>
+        </div>
+
+        <div data-uidotsh-option="Briefing rail" className="contents" hidden>
+          <section className="mx-auto max-w-3xl overflow-hidden rounded-[1.75rem] border border-gray-950/10 bg-white dark:border-white/10 dark:bg-gray-950">
+            <div className="grid lg:grid-cols-[minmax(0,1fr)_minmax(0,0.95fr)]">
+              <div className="border-b border-gray-950/10 p-6 sm:p-8 lg:border-r lg:border-b-0 dark:border-white/10">
+                <p className="font-mono text-sm tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                  Editor&apos;s briefing
+                </p>
+                <h2 className="mt-4 max-w-[18ch] text-2xl font-semibold tracking-tight text-balance text-gray-950 sm:text-3xl dark:text-white">
+                  Stay on the short list for every new issue.
+                </h2>
+                <p className="mt-3 max-w-[46ch] text-base text-pretty text-gray-600 dark:text-gray-300">
+                  One email each time a new post or newsletter drops, with the best lessons pulled
+                  forward for busy founders and marketers.
+                </p>
+                <div className="mt-6 grid gap-4 border-t border-gray-950/10 pt-4 sm:grid-cols-3 dark:border-white/10">
+                  <div className="sm:pr-4 sm:[&:not(:first-child)]:border-l sm:[&:not(:first-child)]:border-gray-950/10 sm:[&:not(:first-child)]:pl-4 dark:sm:[&:not(:first-child)]:border-white/10">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">Cadence</p>
+                    <p className="mt-1 text-base font-medium text-gray-950 dark:text-white">
+                      Weekly
+                    </p>
+                  </div>
+                  <div className="sm:pr-4 sm:[&:not(:first-child)]:border-l sm:[&:not(:first-child)]:border-gray-950/10 sm:[&:not(:first-child)]:pl-4 dark:sm:[&:not(:first-child)]:border-white/10">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">Angle</p>
+                    <p className="mt-1 text-base font-medium text-gray-950 dark:text-white">
+                      GTM analysis
+                    </p>
+                  </div>
+                  <div className="sm:[&:not(:first-child)]:border-l sm:[&:not(:first-child)]:border-gray-950/10 sm:[&:not(:first-child)]:pl-4 dark:sm:[&:not(:first-child)]:border-white/10">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">Noise</p>
+                    <p className="mt-1 text-base font-medium text-gray-950 dark:text-white">
+                      Very low
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div className="bg-gray-50/80 p-6 sm:p-8 dark:bg-white/5">
+                <NewsletterForm
+                  compact
+                  title="Join the readers who want the signal, not the scroll."
+                  description="Drop your email below and the next issue lands in your inbox."
+                  inputId="post-newsletter-briefing"
+                  className="max-w-none border-0 bg-transparent p-0"
+                  titleClassName="max-w-[22ch] text-xl tracking-tight text-balance"
+                  descriptionClassName="max-w-[42ch] text-base text-pretty text-gray-600 dark:text-gray-300"
+                  inputClassName="border-0 bg-white text-base ring-1 ring-black/10 dark:bg-gray-950 dark:ring-white/10"
+                  buttonClassName="w-full sm:w-auto"
+                  buttonSize="sm"
+                />
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <div data-uidotsh-option="Founder's note" className="contents" hidden>
+          <section className="mx-auto max-w-3xl rounded-[1.75rem] border border-gray-950/10 bg-linear-to-r from-gray-50 to-white p-6 text-center sm:p-8 dark:border-white/10 dark:from-white/5 dark:to-gray-950">
+            <div className="mx-auto flex size-14 items-center justify-center rounded-full border border-gray-950/10 bg-white text-sm font-medium text-gray-700 dark:border-white/10 dark:bg-gray-950 dark:text-gray-200">
+              HW
+            </div>
+            <div className="mx-auto mt-5 max-w-2xl space-y-3">
+              <p className="font-mono text-sm tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                A quick note from the editor
+              </p>
+              <h2 className="text-2xl font-semibold tracking-tight text-balance text-gray-950 sm:text-3xl dark:text-white">
+                If this post helped, the newsletter will be even more useful.
+              </h2>
+              <p className="text-base text-pretty text-gray-600 dark:text-gray-300">
+                I send one concise email when there&apos;s a new breakdown worth your time. No drip
+                sequence. No filler. Just the next sharp idea.
+              </p>
+            </div>
+            <NewsletterForm
+              compact
+              title=""
+              description=""
+              inputId="post-newsletter-founder"
+              className="mx-auto mt-6 max-w-xl border-0 bg-transparent p-0"
+              formClassName="mt-0 flex-col gap-3 sm:flex-row sm:items-center"
+              inputClassName="border-0 bg-white text-base ring-1 ring-black/10 dark:bg-gray-950 dark:ring-white/10"
+              buttonClassName="sm:min-w-32"
+            />
+            <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+              Subscribe once. Read when there&apos;s something worth reading.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/data/headerNavLinks.ts
+++ b/data/headerNavLinks.ts
@@ -1,11 +1,6 @@
 const headerNavLinks = [
   { href: '/', title: 'Home' },
-  { href: '/blog', title: 'Blog' },
-  { href: '/tags', title: 'Tags' },
-  // TODO: Add custom projects before re-enabling the Projects link
-  // { href: '/projects', title: 'Projects' },
-  { href: '/contact', title: 'Contact' },
-  { href: '/about', title: 'About' },
+  { href: '/about', title: 'Work With Me' },
 ]
 
 export default headerNavLinks

--- a/layouts/PostBanner.tsx
+++ b/layouts/PostBanner.tsx
@@ -7,6 +7,7 @@ import PageTitle from '@/components/PageTitle'
 import SectionContainer from '@/components/SectionContainer'
 import siteMetadata from '@/data/siteMetadata'
 import ScrollTopAndComment from '@/components/ScrollTopAndComment'
+import PostSubscribeBox from '@/components/PostSubscribeBox'
 import type { SitePost, SitePostLink } from 'src/payload/types'
 
 interface LayoutProps {
@@ -36,6 +37,7 @@ export default function PostMinimal({ content, next, prev, children }: LayoutPro
             </div>
             <div className="relative pt-10">
               <PageTitle>{title}</PageTitle>
+              <PostSubscribeBox />
             </div>
           </div>
           <div className="prose dark:prose-invert max-w-none py-4">{children}</div>

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -7,6 +7,7 @@ import Image from '@/components/Image'
 import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
 import ScrollTopAndComment from '@/components/ScrollTopAndComment'
+import PostSubscribeBox from '@/components/PostSubscribeBox'
 import type { SiteAuthor, SitePost, SitePostLink } from 'src/payload/types'
 
 const editUrl = (path) => `${siteMetadata.siteRepo}/blob/main/data/${path}`
@@ -52,6 +53,7 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
               <div>
                 <PageTitle>{title}</PageTitle>
               </div>
+              <PostSubscribeBox />
             </div>
           </header>
           <div className="grid-rows-[auto_1fr] divide-y divide-gray-200 pb-8 xl:grid xl:grid-cols-4 xl:gap-x-6 xl:divide-y-0 dark:divide-gray-700">

--- a/layouts/PostSimple.tsx
+++ b/layouts/PostSimple.tsx
@@ -6,6 +6,7 @@ import PageTitle from '@/components/PageTitle'
 import SectionContainer from '@/components/SectionContainer'
 import siteMetadata from '@/data/siteMetadata'
 import ScrollTopAndComment from '@/components/ScrollTopAndComment'
+import PostSubscribeBox from '@/components/PostSubscribeBox'
 import type { SitePost, SitePostLink } from 'src/payload/types'
 
 interface LayoutProps {
@@ -36,6 +37,7 @@ export default function PostLayout({ content, next, prev, children }: LayoutProp
               <div>
                 <PageTitle>{title}</PageTitle>
               </div>
+              <PostSubscribeBox />
             </div>
           </header>
           <div className="grid-rows-[auto_1fr] divide-y divide-gray-200 pb-8 xl:divide-y-0 dark:divide-gray-700">

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -49,6 +49,7 @@ const envSchema = z.object({
     .trim()
     .email('CONTACT_FORM_RECIPIENT must be an email')
     .optional(),
+  CONTACT_FORM_FROM: z.string().trim().optional(),
   NODE_ENV: z
     .enum(['development', 'test', 'production'])
     .default(process.env.NODE_ENV || 'development'),

--- a/next.config.js
+++ b/next.config.js
@@ -2,9 +2,17 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 })
 
-const scriptHosts = new Set(['giscus.app', 'analytics.umami.is'])
+const scriptHosts = new Set(['giscus.app', 'analytics.umami.is', 'cloud.umami.is'])
+if (process.env.NODE_ENV === 'development') {
+  scriptHosts.add('ui.sh')
+}
 const frameHosts = new Set(['giscus.app'])
-const connectHosts = new Set(['api.resend.com', 'fonts.googleapis.com', 'analytics.umami.is'])
+const connectHosts = new Set([
+  'api.resend.com',
+  'fonts.googleapis.com',
+  'analytics.umami.is',
+  'cloud.umami.is',
+])
 const imgHosts = ['*', 'blob:', 'data:']
 
 const ContentSecurityPolicy = `


### PR DESCRIPTION
## Summary

- Turns the About page into a services-oriented "Work With Me" page with a side contact form.
- Updates the homepage: removes post dates, links the editor byline to the services page, adds a second newsletter signup, and emphasizes "business" in the headline.
- Simplifies the header navigation to a single "Work With Me" link and adds reusable newsletter/signup components for posts.
- Gates the ui.sh picker script to development, tightens CSP accordingly, and ignores local browser/test artifacts and env backups.
- Fixes the contact form sender to use the verified `hypeburner.com` Resend domain, sets submitter email as `replyTo`, adds plain-text email content, and escapes submitted HTML.

## Validation

- `npx eslint "app/(site)/layout.tsx" "app/(site)/Main.tsx" next.config.js`
- `npx eslint app/api/contact/route.ts lib/env.ts`
- `git diff --check`
- Pre-commit `lint-staged` ran `eslint --fix` and `prettier --write` on staged files.
- Resend MCP confirmed `hypeburner.com` is verified and sending-enabled.
- Tested `/contact` with `CONTACT_FORM_RECIPIENT=bolddesign84@agentmail.to`: UI success, `POST /api/contact 200`, Resend delivered email `e11f4ad8-77ba-4fa8-be71-7a7e57ba17aa`.
- Tested `/about` Work With Me form with `CONTACT_FORM_RECIPIENT=bolddesign84@agentmail.to`: UI success, `POST /api/contact 200`, Resend delivered email `52068fc3-fde0-433f-985d-290d30fdcfb1`.
- Verified both delivered messages appeared on the AgentMail page for `bolddesign84@agentmail.to`.

## Notes

Full `npm run lint -- --quiet` still fails on an unrelated existing `react-hooks/set-state-in-effect` issue in `components/ThemeSwitch.tsx` and one existing warning in `components/Link.tsx`.

The Vercel preview endpoint is deployment-protected and returned `401` before reaching the app route, so the full form delivery test was run locally against the same route with a temporary AgentMail recipient override.

Earlier sends to `editor@hypeburner.com` were accepted by Resend but marked `suppressed`; that recipient should be removed from Resend suppressions or replaced with a non-suppressed inbox before relying on production delivery.

I intentionally left the separate Payload rich-text repair changes uncommitted because they are outside this PR's service-page scope.